### PR TITLE
split out shell script into multiple tasks

### DIFF
--- a/roles/hana-host/tasks/main.yml
+++ b/roles/hana-host/tasks/main.yml
@@ -4,13 +4,9 @@
   debug:
     verbosity: "{{ debuglevel }}"
 
-- name: check default gateway
-  shell: route -n
-  register: route
-
 - name: set default gateway
   shell: route add default gw 192.168.0.2
-  when: ( ansible_default_ipv4.gateway != "192.168.0.2" )
+  when: ansible_default_ipv4.gateway is undefined
 
 - include: ./system-registration-part1.yml
   when: check_repos

--- a/roles/hana-host/tasks/main.yml
+++ b/roles/hana-host/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: set default gateway
   shell: route add default gw 192.168.0.2
-  when: ( route.stdout != 192.168.0.2 )
+  when: ( route.stdout != "192.168.0.2" )
 
 - include: ./system-registration-part1.yml
   when: check_repos

--- a/roles/hana-host/tasks/main.yml
+++ b/roles/hana-host/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: set default gateway
   shell: route add default gw 192.168.0.2
-  when: ( route.stdout != "192.168.0.2" )
+  when: ( ansible_default_ipv4.gateway != "192.168.0.2" )
 
 - include: ./system-registration-part1.yml
   when: check_repos

--- a/roles/hana-host/tasks/main.yml
+++ b/roles/hana-host/tasks/main.yml
@@ -4,8 +4,13 @@
   debug:
     verbosity: "{{ debuglevel }}"
 
+- name: check default gateway
+  shell: route -n
+  register: route
+
 - name: set default gateway
   shell: route add default gw 192.168.0.2
+  when: ( route.stdout != 192.168.0.2 )
 
 - include: ./system-registration-part1.yml
   when: check_repos

--- a/roles/hana-host/tasks/sap-check-media.yml
+++ b/roles/hana-host/tasks/sap-check-media.yml
@@ -30,37 +30,23 @@
     owner: root
     group: root
 
+- name: mount installdir
+  mount:
+      src: {{ install_nfs }} 
+      name: /tmp/install
+      fstype: nfs
+      state: mounted
+  when: not( (install_nfs is undefined) or (install_nfs is none) or (install_nfs | trim == '') )
 
-- name: Make Installdir available at '{{ installroot }}'
-  shell: |
-    INSTDIR='{{ installroot }}'
-    VERSION='{{ installversion }}'
-    MOUNTP='{{ install_nfs }}'
-    if [ -f "${INSTDIR}/${VERSION}/DATA_UNITS/HDB_SERVER_LINUX_X86_64/hdblcm" ]; then
-       rc=0
-    else
-       TDIR=$(mktemp -d)
-       trap "{ cd / ; rm -rf $TDIR; exit 255; }" SIGINT
-       mount -t nfs $MOUNTP $TDIR
-       if [ -d "${TDIR}/${VERSION}" ]; then 
-          umount "$TDIR"
-          mount -t nfs $MOUNTP $INSTDIR
-          rc=1
-       else
-          if [ -f "${TDIR}/${VERSION}_part1.exe" ]; then 
-             ( cd $INSTDIR; unrar x "${TDIR}/${VERSION}_part1.exe" )
-             umount ${TDIR}
-             rc=1
-          else
-             rc=2
-          fi
-       fi 
-    fi
-    rm -rf $TDIR
-    exit $rc
-  register: unpack_hana 
-  changed_when: unpack_hana.rc == 1
-  failed_when: unpack_hana.rc >= 2 
+- name: extract installer
+  shell: cd {{ installroot }} && unrar x "/tmp/install/{{ installversion }}_part1.exe"
+  
+- name: mount installdir
+  mount:
+      src: {{ install_nfs }} 
+      name: /tmp/install
+      fstype: nfs
+      state: unmounted
   when: not( (install_nfs is undefined) or (install_nfs is none) or (install_nfs | trim == '') )
 
 - name: Get HANA Version Information

--- a/roles/hana-host/tasks/sap-check-media.yml
+++ b/roles/hana-host/tasks/sap-check-media.yml
@@ -32,7 +32,7 @@
 
 - name: mount installdir
   mount:
-      src: {{ install_nfs }} 
+      src: "{{ install_nfs }}"
       name: /tmp/install
       fstype: nfs
       state: mounted
@@ -43,7 +43,7 @@
   
 - name: mount installdir
   mount:
-      src: {{ install_nfs }} 
+      src: "{{ install_nfs }}"
       name: /tmp/install
       fstype: nfs
       state: unmounted


### PR DESCRIPTION
there shell script did a sequence of steps which should better be split into individual tasks

I also don't see a reason to make the mount point dynamic, so I always use /tmp/install. Which IMHO is actually not a good mount point in the first place, since /tmp should not be used to mount NFS shares to in the first place. 