### PR TITLE
Modified RHEL 6 & 7 tasks to use a list of items declared in vars/main.yml

### DIFF
--- a/roles/base-host-setup/tasks/RedHat6/system-registration.yml
+++ b/roles/base-host-setup/tasks/RedHat6/system-registration.yml
@@ -5,18 +5,16 @@
   register: repolist
 
 - name: Set latest supported RedHat EUS release
-  shell: "subscription-manager release --set=6.7" 
+  shell: "subscription-manager release --set=6.7"
   register: rh_release
   changed_when: rh_release.rc == 0
   failed_when: rh_release.rc > 0
-  when: ( ansible_distribution_version != 6.7 )
+  when: ansible_distribution_major_version = 6"
 
 - name: ensure system has access to the right repos
   shell: "subscription-manager repos --enable={{ item }}"
   with_items:
-    - rhel-6-server-eus-rpms
-    - rhel-sap-hana-for-rhel-6-server-eus-rpms
-    - rhel-sfs-for-rhel-6-server-eus-rpms
+    "{{ rhel_6_repos }}"
   when: "repolist.stdout.find('{{ item }}') == -1"
 
 ...

--- a/roles/base-host-setup/tasks/RedHat7/system-registration.yml
+++ b/roles/base-host-setup/tasks/RedHat7/system-registration.yml
@@ -1,8 +1,8 @@
 ---
 
-# Unusable if Release is changing 
+# Unusable if Release is changing
 #- name: Set latest supported RedHat EUS release
-#  shell: subscription-manager release --set=7.2 
+#  shell: subscription-manager release --set=7.2
 #  register: rh_release
 #  changed_when: rh_release.rc == 0
 #  failed_when: rh_release.rc > 0
@@ -12,8 +12,7 @@
 - name: ensure system has access to the right repos
   shell: "subscription-manager repos --enable={{ item }}"
   with_items:
-    - rhel-7-server-eus-rpms
-    - rhel-sap-hana-for-rhel-7-server-eus-rpms
+    "{{ rhel_7_repos }}"
   when: "repolist.stdout.find('{{ item }}') == -1"
 
 ...

--- a/roles/base-host-setup/vars/main.yml
+++ b/roles/base-host-setup/vars/main.yml
@@ -5,11 +5,20 @@
 # Want extensive debugging
 debuglevel: 3
 #
-#  System Registration. 
+#  System Registration.
 # assuming system is properly configured, just want to add required channels
 force_repo_reset: false
 check_repos: true
 
+rhel_7_repos:
+  - rhel-7-server-eus-rpms
+  - rhel-sap-hana-for-rhel-7-server-eus-rpms
+
+rhel_6_repos:
+  - rhel-6-server-eus-rpms
+  - rhel-sap-hana-for-rhel-6-server-eus-rpms
+  - rhel-sfs-for-rhel-6-server-eus-rpms
+  
 # Disk Setup
 # disk setup is done by kickstart, so no need to change anything here
 disk_partitioning: false
@@ -48,4 +57,3 @@ logvols:
     pvs: /dev/vdb1
 
 ...
-    


### PR DESCRIPTION
Changed check for RHEL 6 release version to major version. If we need to
set it to RHEL 6.7, we don't need additional logic.. if release is any version of 6, set it to 6.7. 

No change in the end result but shortens the playbook and improves legibility.

This should allow us to consolidate all these task files down into one
or two tasks without system specific folders